### PR TITLE
Add custom speed dial controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Try the **[live demo](https://robbendebiene.github.io/freestyle_speed_dial/)** o
 
 ### Building the main button
 
-The starting point of ever speed dial button is a main toggle button. Use the `buttonBuilder` to create your own custom toggle button. You can use any combination of widgets there. The only important thing is, that one of the widgets must call the `toggle` function provided by the builder on your desired user interaction.
-To reflect the state of the speed dial you can alter your widget based on the `isActive` parameter. To transition between both states consider using an `AnimatedSwitcher` or any other [flutter implicitly animated widget](https://api.flutter.dev/flutter/widgets/ImplicitlyAnimatedWidget-class.html).
+The starting point of every speed dial button is the main toggle button. Use the `buttonBuilder` to create your own custom toggle button. You can use any combination of widgets there. The only important thing is, that one of the widgets must call the `controller.toggle` function provided by the builder on your desired user interaction.
+To reflect the state of the speed dial you can alter your widget based on the `controller.isActive`, `controller.status` or `controller.animation` parameter using a transition widget or something like an [AnimatedBuilder](https://api.flutter.dev/flutter/widgets/AnimatedBuilder-class.html). Either listen to the `controller` for status changes or to the `controller.animation` to animate together with the speed dial.
 
 Basic example code:
 
@@ -22,9 +22,14 @@ Basic example code:
 ```dart
 SpeedDialBuilder(
   ...
-  buttonBuilder: (context, isActive, toggle) => FloatingActionButton(
-    onPressed: toggle,
-    child: Icon( isActive ? Icons.close : Icons.add )
+  buttonBuilder: (context, controller) => FloatingActionButton(
+    onPressed: controller.toggle,
+    child: ListenableBuilder(
+      listenable: controller,
+      builder: (BuildContext context, Widget? child) {
+        return Icon( controller.isActive ? Icons.close : Icons.add );
+      }
+    )
   )
 )
 ```
@@ -61,7 +66,7 @@ SpeedDialBuilder(
   ...
   buttonAnchor: Alignment.topCenter,
   itemAnchor: Alignment.bottomCenter,
-  itemBuilder: (context, Widget item, i, animation) => FractionalTranslation(
+  itemBuilder: (context, Widget item, i, animation, controller) => FractionalTranslation(
     translation: Offset(0, -i.toDouble()),
     child: ScaleTransition(
       scale: animation,
@@ -80,11 +85,16 @@ Think of it as defining two points, one on the main button that is fixed and one
 SpeedDialBuilder(
   buttonAnchor: Alignment.topCenter,
   itemAnchor: Alignment.bottomCenter,
-  buttonBuilder: (context, isActive, toggle) => FloatingActionButton(
-    onPressed: toggle,
-    child: Icon( isActive ? Icons.close : Icons.add )
+  buttonBuilder: (context, controller) => FloatingActionButton(
+    onPressed: controller.toggle,
+    child: ListenableBuilder(
+      listenable: controller,
+      builder: (BuildContext context, Widget? child) {
+        return Icon( controller.isActive ? Icons.close : Icons.add );
+      }
+    )
   ),
-  itemBuilder: (context, Widget item, i, animation) => FractionalTranslation(
+  itemBuilder: (context, Widget item, i, animation, controller) => FractionalTranslation(
     translation: Offset(0, -i.toDouble()),
     child: ScaleTransition(
       scale: animation,
@@ -115,11 +125,16 @@ The below example uses the `secondaryItemBuilder` in combination with Flutters [
 SpeedDialBuilder(
   buttonAnchor: Alignment.topCenter,
   itemAnchor: Alignment.bottomCenter,
-  buttonBuilder: (context, isActive, toggle) => FloatingActionButton(
-    onPressed: toggle,
-    child: Icon( isActive ? Icons.close : Icons.add )
+  buttonBuilder: (context, controller) => FloatingActionButton(
+    onPressed: controller.toggle,
+    child: ListenableBuilder(
+      listenable: controller,
+      builder: (BuildContext context, Widget? child) {
+        return Icon( controller.isActive ? Icons.close : Icons.add );
+      }
+    )
   ),
-  itemBuilder: (context, (IconData, String, LayerLink) item, i, animation) {
+  itemBuilder: (context, (IconData, String, LayerLink) item, i, animation, controller) {
     return FractionalTranslation(
       translation: Offset(0, -i.toDouble()),
       child: CompositedTransformTarget(
@@ -134,7 +149,7 @@ SpeedDialBuilder(
       )
     );
   },
-  secondaryItemBuilder: (context, (IconData, String, LayerLink) item, i, animation) {
+  secondaryItemBuilder: (context, (IconData, String, LayerLink) item, i, animation, controller) {
     return CompositedTransformFollower(
       link: item.$3,
       targetAnchor: Alignment.centerRight,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -46,41 +46,24 @@ class ExamplePage extends StatelessWidget {
               // Simple speed dial where every sub-button/item animates starting
               // from its own final position.
               SpeedDialBuilder(
-                buttonBuilder: (context, isActive, toggle) => FloatingActionButton(
-                  onPressed: toggle,
-                  child: AnimatedRotation(
-                    duration: const Duration(milliseconds: 300),
-                    curve: Curves.easeInOutCubicEmphasized,
-                    turns: isActive ? 0.125 : 0,
-                    child: const Icon( Icons.add )
-                  )
-                ),
+                buttonBuilder: spinButtonBuilder,
                 buttonAnchor: Alignment.topCenter,
                 itemAnchor: Alignment.bottomCenter,
-                itemBuilder: (context, Widget item, i, animation) => FractionalTranslation(
+                itemBuilder: (context, Widget item, i, animation, controller) => FractionalTranslation(
                   translation: Offset(0, -i.toDouble()),
                   child: ScaleTransition(
                     scale: animation,
-                    child: item
+                    child: FloatingActionButton.small(
+                      onPressed: controller.close,
+                      child: item,
+                    ),
                   )
                 ),
-                items: [
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.hub),
-                  ),
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.file_download),
-                  ),
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.wallet),
-                  ),
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.sd_card),
-                  )
+                items: const [
+                  Icon(Icons.hub),
+                  Icon(Icons.file_download),
+                  Icon(Icons.wallet),
+                  Icon(Icons.sd_card),
                 ]
               ),
 
@@ -89,18 +72,10 @@ class ExamplePage extends StatelessWidget {
               // Simple speed dial where every sub-button/item animates starting
               // from the FABs position to its final position.
               SpeedDialBuilder(
-                buttonBuilder: (context, isActive, toggle) => FloatingActionButton(
-                  onPressed: toggle,
-                  child: AnimatedRotation(
-                    duration: const Duration(milliseconds: 300),
-                    curve: Curves.easeInOutCubicEmphasized,
-                    turns: isActive ? 0.125 : 0,
-                    child: const Icon( Icons.add )
-                  )
-                ),
+                buttonBuilder: spinButtonBuilder,
                 curve: Curves.easeInOutCubicEmphasized,
                 reverse: true,
-                itemBuilder: (context, Widget item, i, animation) {
+                itemBuilder: (context, Widget item, i, animation, controller) {
                   final offsetAnimation = Tween<Offset>(
                     begin: Offset.zero,
                     end: Offset(0, -i - 1),
@@ -109,27 +84,18 @@ class ExamplePage extends StatelessWidget {
                     position: offsetAnimation,
                     child: FadeTransition(
                       opacity: animation,
-                      child: item,
+                      child: FloatingActionButton.small(
+                        onPressed: controller.close,
+                        child: item,
+                      ),
                     )
                   );
                 },
-                items: [
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.hub),
-                  ),
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.file_download),
-                  ),
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.wallet),
-                  ),
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.sd_card),
-                  )
+                items: const [
+                  Icon(Icons.hub),
+                  Icon(Icons.file_download),
+                  Icon(Icons.wallet),
+                  Icon(Icons.sd_card),
                 ]
               ),
 
@@ -140,26 +106,20 @@ class ExamplePage extends StatelessWidget {
               SpeedDialBuilder(
                 buttonAnchor: Alignment.center,
                 itemAnchor: Alignment.center,
-                buttonBuilder: (context, isActive, toggle) => FloatingActionButton(
-                  onPressed: toggle,
-                  child: AnimatedRotation(
-                    duration: const Duration(milliseconds: 300),
-                    curve: Curves.easeInOutCubicEmphasized,
-                    turns: isActive ? 0.125 : 0,
-                    child: const Icon( Icons.add )
-                  )
-                ),
+                buttonBuilder: spinButtonBuilder,
                 curve: Curves.easeInOutCubicEmphasized,
                 reverse: true,
-                itemBuilder: (context, Widget item, i, animation) {
+                itemBuilder: (context, Widget item, i, animation, controller) {
                   // radius in relative units to each item
                   const radius = 1.3;
+                  // item spacing
+                  const spacing = 0.1;
                   // angle in radians
                   const angle = -3/4 * pi;
 
                   final targetOffset = Offset(
-                    (i + radius) * cos(angle),
-                    (i + radius) * sin(angle)
+                    (i + radius) * cos(angle) - i * spacing,
+                    (i + radius) * sin(angle) - i * spacing
                   );
 
                   final offsetAnimation = Tween<Offset>(
@@ -170,27 +130,18 @@ class ExamplePage extends StatelessWidget {
                     position: offsetAnimation,
                     child: FadeTransition(
                       opacity: animation,
-                      child: item,
+                      child: FloatingActionButton.small(
+                        onPressed: controller.close,
+                        child: item,
+                      ),
                     )
                   );
                 },
-                items: [
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.hub),
-                  ),
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.file_download),
-                  ),
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.wallet),
-                  ),
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.sd_card),
-                  )
+                items: const [
+                  Icon(Icons.hub),
+                  Icon(Icons.file_download),
+                  Icon(Icons.wallet),
+                  Icon(Icons.sd_card),
                 ]
               ),
 
@@ -201,16 +152,8 @@ class ExamplePage extends StatelessWidget {
               SpeedDialBuilder(
                 buttonAnchor: Alignment.center,
                 itemAnchor: Alignment.center,
-                buttonBuilder: (context, isActive, toggle) => FloatingActionButton(
-                  onPressed: toggle,
-                  child: AnimatedRotation(
-                    duration: const Duration(milliseconds: 300),
-                    curve: Curves.easeInOutCubicEmphasized,
-                    turns: isActive ? 0.125 : 0,
-                    child: const Icon( Icons.add )
-                  )
-                ),
-                itemBuilder: (context, Widget item, i, animation) {
+                buttonBuilder: spinButtonBuilder,
+                itemBuilder: (context, Widget item, i, animation, controller) {
                   // radius in relative units to each item
                   const radius = 1.3;
                   // angle in radians
@@ -230,23 +173,17 @@ class ExamplePage extends StatelessWidget {
                     position: offsetAnimation,
                     child: FadeTransition(
                       opacity: animation,
-                      child: item,
+                      child: FloatingActionButton.small(
+                        onPressed: controller.close,
+                        child: item,
+                      ),
                     )
                   );
                 },
-                items: [
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.hub),
-                  ),
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.file_download),
-                  ),
-                  FloatingActionButton.small(
-                    onPressed: () {},
-                    child: const Icon(Icons.wallet),
-                  ),
+                items: const [
+                  Icon(Icons.hub),
+                  Icon(Icons.file_download),
+                  Icon(Icons.wallet),
                 ]
               ),
 
@@ -257,16 +194,8 @@ class ExamplePage extends StatelessWidget {
               SpeedDialBuilder(
                 buttonAnchor: Alignment.topCenter,
                 itemAnchor: Alignment.bottomCenter,
-                buttonBuilder: (context, isActive, toggle) => FloatingActionButton(
-                  onPressed: toggle,
-                  child: AnimatedRotation(
-                    duration: const Duration(milliseconds: 300),
-                    curve: Curves.easeInOutCubicEmphasized,
-                    turns: isActive ? 0.125 : 0,
-                    child: const Icon( Icons.add )
-                  )
-                ),
-                itemBuilder: (context, (IconData, String, LayerLink) item, i, animation) {
+                buttonBuilder: spinButtonBuilder,
+                itemBuilder: (context, (IconData, String, LayerLink) item, i, animation, controller) {
                   return FractionalTranslation(
                     translation: Offset(0, -i.toDouble()),
                     child: CompositedTransformTarget(
@@ -274,14 +203,14 @@ class ExamplePage extends StatelessWidget {
                       child: ScaleTransition(
                         scale: animation,
                         child: FloatingActionButton.small(
-                          onPressed: () {},
+                          onPressed: controller.close,
                           child: Icon(item.$1),
                         ),
                       )
                     )
                   );
                 },
-                secondaryItemBuilder: (context, (IconData, String, LayerLink) item, i, animation) {
+                secondaryItemBuilder: (context, (IconData, String, LayerLink) item, i, animation, controller) {
                   return CompositedTransformFollower(
                     link: item.$3,
                     targetAnchor: Alignment.centerRight,
@@ -300,7 +229,7 @@ class ExamplePage extends StatelessWidget {
                 },
                 items: [
                   // You can also define and use your own container class
-                  // if you don't want to use the tuple package.
+                  // if you don't want to use records.
                   (Icons.hub, 'Hub', LayerLink()),
                   (Icons.track_changes, 'Track', LayerLink()),
                   (Icons.ice_skating_outlined, 'Ice', LayerLink()),
@@ -312,17 +241,9 @@ class ExamplePage extends StatelessWidget {
               // Advanced speed dial where every sub-button/item has an additional label.
               // Both the item and the label start animating from their target position.
               SpeedDialBuilder(
-                buttonBuilder: (context, isActive, toggle) => FloatingActionButton(
-                  onPressed: toggle,
-                  child: AnimatedRotation(
-                    duration: const Duration(milliseconds: 300),
-                    curve: Curves.easeInOutCubicEmphasized,
-                    turns: isActive ? 0.125 : 0,
-                    child: const Icon( Icons.add )
-                  )
-                ),
+                buttonBuilder: spinButtonBuilder,
                 reverse: true,
-                itemBuilder: (context, (IconData, String, LayerLink) item, i, animation) {
+                itemBuilder: (context, (IconData, String, LayerLink) item, i, animation, controller) {
                   final offsetAnimation = Tween<Offset>(
                     begin: Offset.zero,
                     end: Offset(0, -i - 1),
@@ -334,14 +255,14 @@ class ExamplePage extends StatelessWidget {
                       child: CompositedTransformTarget(
                         link: item.$3,
                         child: FloatingActionButton.small(
-                          onPressed: () {},
+                          onPressed: controller.close,
                           child: Icon(item.$1),
                         ),
                       )
                     )
                   );
                 },
-                secondaryItemBuilder: (context, (IconData, String, LayerLink) item, i, animation) {
+                secondaryItemBuilder: (context, (IconData, String, LayerLink) item, i, animation, controller) {
                   return CompositedTransformFollower(
                     link: item.$3,
                     targetAnchor: Alignment.centerRight,
@@ -360,7 +281,7 @@ class ExamplePage extends StatelessWidget {
                 },
                 items: [
                   // You can also define and use your own container class
-                  // if you don't want to use the tuple package.
+                  // if you don't want to use records.
                   (Icons.hub, 'Hub', LayerLink()),
                   (Icons.track_changes, 'Track', LayerLink()),
                   (Icons.ice_skating_outlined, 'Ice', LayerLink()),
@@ -373,3 +294,16 @@ class ExamplePage extends StatelessWidget {
     );
   }
 }
+
+
+Widget spinButtonBuilder(context, controller) => FloatingActionButton(
+  onPressed: controller.toggle,
+  child: RotationTransition(
+    turns: Tween(begin: 0.0, end: 0.125).animate(CurvedAnimation(
+      parent: controller.animation,
+      curve: Curves.easeInOutCubicEmphasized,
+      reverseCurve: Curves.easeInOutCubicEmphasized.flipped,
+    )),
+    child: const Icon( Icons.add )
+  ),
+);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/Robbendebiene/freestyle_speed_dial
 issue_tracker: https://github.com/Robbendebiene/freestyle_speed_dial/issues
 
 environment:
-  sdk: ">=2.17.5 <3.0.0"
+  sdk: ">=2.17.5 <4.0.0"
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
This introduces a central controller for the speed dial builder. It can be used to open, close and toggle the speed dial, listen to status changes or to obtain the main animation.

Resolves #5